### PR TITLE
Image creation reponse changed with new url field

### DIFF
--- a/lib/src/models/image_generation.dart
+++ b/lib/src/models/image_generation.dart
@@ -31,22 +31,26 @@ class ImageGenerationResponse {
 
 class ImageData {
   final int index;
-  final String b64Json;
+  //final String b64Json;
+  final String url;
 
   ImageData({
     required this.index,
-    required this.b64Json,
+    //required this.b64Json,
+    required this.url,
   });
 
   factory ImageData.fromJson(Map<String, dynamic> json) {
     return ImageData(
       index: json['index'],
-      b64Json: json['b64_json'],
+      //b64Json: json['b64_json'],
+      url: json["url"],
     );
   }
 
   @override
   String toString() {
-    return 'ImageData(index: $index, b64Json: $b64Json)';
+    //return 'ImageData(index: $index, b64Json: $b64Json)';
+    return 'ImageData(index: $index, url: $url)';
   }
 }

--- a/lib/src/models/image_generation.dart
+++ b/lib/src/models/image_generation.dart
@@ -1,5 +1,10 @@
 // Image Generation Model
 
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
 class ImageGenerationResponse {
   final String id;
   final String model;
@@ -52,5 +57,32 @@ class ImageData {
   String toString() {
     //return 'ImageData(index: $index, b64Json: $b64Json)';
     return 'ImageData(index: $index, url: $url)';
+  }
+
+  // Convert the image url to a b64 encoded image data url
+  Future<String?> toB64DataUrl() async {
+      final dio = Dio();
+  
+      try {
+      // Fetch the image data from the URL
+      final response = await dio.get(url, options: Options(responseType: ResponseType.bytes));
+    
+      if (response.statusCode == 200) {
+        // Convert the image bytes to Base64
+        Uint8List imageBytes = Uint8List.fromList(response.data);
+        String base64Image = base64Encode(imageBytes);
+      
+        // Construct the Data URL (assuming JPEG format)
+        String dataUrl = 'data:image/jpeg;base64,$base64Image';
+        //print('Data URL: $dataUrl');
+        return dataUrl;
+      } else {
+        print('Failed to load image. Status code: ${response.statusCode}');
+        return null;
+      }
+    } catch (e) {
+      print('Error occurred: $e');
+      return null;
+    }
   }
 }

--- a/lib/src/models/image_generation.dart
+++ b/lib/src/models/image_generation.dart
@@ -1,10 +1,5 @@
 // Image Generation Model
 
-import 'dart:convert';
-import 'dart:typed_data';
-
-import 'package:dio/dio.dart';
-
 class ImageGenerationResponse {
   final String id;
   final String model;
@@ -57,32 +52,5 @@ class ImageData {
   String toString() {
     //return 'ImageData(index: $index, b64Json: $b64Json)';
     return 'ImageData(index: $index, url: $url)';
-  }
-
-  // Convert the image url to a b64 encoded image data url
-  Future<String?> toB64DataUrl() async {
-      final dio = Dio();
-  
-      try {
-      // Fetch the image data from the URL
-      final response = await dio.get(url, options: Options(responseType: ResponseType.bytes));
-    
-      if (response.statusCode == 200) {
-        // Convert the image bytes to Base64
-        Uint8List imageBytes = Uint8List.fromList(response.data);
-        String base64Image = base64Encode(imageBytes);
-      
-        // Construct the Data URL (assuming JPEG format)
-        String dataUrl = 'data:image/jpeg;base64,$base64Image';
-        //print('Data URL: $dataUrl');
-        return dataUrl;
-      } else {
-        print('Failed to load image. Status code: ${response.statusCode}');
-        return null;
-      }
-    } catch (e) {
-      print('Error occurred: $e');
-      return null;
-    }
   }
 }

--- a/lib/src/repositories/together_ai_sdk.dart
+++ b/lib/src/repositories/together_ai_sdk.dart
@@ -201,13 +201,13 @@ class TogetherAISdk {
     int n = 1,
     int steps = 10,
   }) async {
-    //TODO 4: Add link for more information on the parameters
+    //More info here: https://docs.together.ai/reference/post_images-generations
     try {
       final response = await dio.post('/v1/images/generations', data: {
         'model': imageModel.toString(),
         'prompt': prompt,
-        'n': n,
-        'steps': steps,
+        'n': n, //Number of image results to generate
+        'steps': steps, //Number of generation steps
       });
       final data = response.data;
       developer.log('Data: ${data}', name: 'together_ai_sdk.name');

--- a/lib/src/repositories/together_ai_sdk.dart
+++ b/lib/src/repositories/together_ai_sdk.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:together_ai_sdk/src/common/enum_ai_models.dart';
@@ -312,6 +313,33 @@ Future<String> imageToBase64(String imagePath) async {
 
   return "data:image/jpeg;base64,$base64Image";
 }
+
+// Convert the image url to a b64 encoded image data url
+  Future<String?> imageUrlToBase64(String imageUrl) async {
+      final dio = Dio();
+  
+      try {
+      // Fetch the image data from the URL
+      final response = await dio.get(imageUrl, options: Options(responseType: ResponseType.bytes));
+    
+      if (response.statusCode == 200) {
+        // Convert the image bytes to Base64
+        Uint8List imageBytes = Uint8List.fromList(response.data);
+        String base64Image = base64Encode(imageBytes);
+      
+        // Construct the Data URL (assuming JPEG format)
+        String dataUrl = 'data:image/jpeg;base64,$base64Image';
+        //print('Data URL: $dataUrl');
+        return dataUrl;
+      } else {
+        print('Failed to load image. Status code: ${response.statusCode}');
+        return null;
+      }
+    } catch (e) {
+      print('Error occurred: $e');
+      return null;
+    }
+  }
 
 //Deprecated code
 

--- a/lib/src/repositories/together_ai_sdk.dart
+++ b/lib/src/repositories/together_ai_sdk.dart
@@ -209,7 +209,7 @@ class TogetherAISdk {
         'steps': steps,
       });
       final data = response.data;
-      print(data);
+      developer.log('Data: ${data}', name: 'together_ai_sdk.name');
       return ImageGenerationResponse.fromJson(data);
     } on DioException catch (e) {
       developer.log(e.toString());

--- a/lib/src/repositories/together_ai_sdk.dart
+++ b/lib/src/repositories/together_ai_sdk.dart
@@ -315,31 +315,31 @@ Future<String> imageToBase64(String imagePath) async {
 }
 
 // Convert the image url to a b64 encoded image data url
-  Future<String?> imageUrlToBase64(String imageUrl) async {
-      final dio = Dio();
+Future<String?> imageUrlToBase64(String imageUrl) async {
+    final dio = Dio();
+
+    try {
+    // Fetch the image data from the URL
+    final response = await dio.get(imageUrl, options: Options(responseType: ResponseType.bytes));
   
-      try {
-      // Fetch the image data from the URL
-      final response = await dio.get(imageUrl, options: Options(responseType: ResponseType.bytes));
+    if (response.statusCode == 200) {
+      // Convert the image bytes to Base64
+      Uint8List imageBytes = Uint8List.fromList(response.data);
+      String base64Image = base64Encode(imageBytes);
     
-      if (response.statusCode == 200) {
-        // Convert the image bytes to Base64
-        Uint8List imageBytes = Uint8List.fromList(response.data);
-        String base64Image = base64Encode(imageBytes);
-      
-        // Construct the Data URL (assuming JPEG format)
-        String dataUrl = 'data:image/jpeg;base64,$base64Image';
-        //print('Data URL: $dataUrl');
-        return dataUrl;
-      } else {
-        print('Failed to load image. Status code: ${response.statusCode}');
-        return null;
-      }
-    } catch (e) {
-      print('Error occurred: $e');
+      // Construct the Data URL (assuming JPEG format)
+      String dataUrl = 'data:image/jpeg;base64,$base64Image';
+      //print('Data URL: $dataUrl');
+      return dataUrl;
+    } else {
+      print('Failed to load image. Status code: ${response.statusCode}');
       return null;
     }
+  } catch (e) {
+    print('Error occurred: $e');
+    return null;
   }
+}
 
 //Deprecated code
 

--- a/test/together_ai_sdk_test.dart
+++ b/test/together_ai_sdk_test.dart
@@ -1,4 +1,5 @@
 import 'package:together_ai_sdk/src/models/chat_completion.dart';
+import 'package:together_ai_sdk/src/models/image_generation.dart';
 import 'package:together_ai_sdk/src/models/text_completion.dart';
 import 'package:together_ai_sdk/together_ai_sdk.dart';
 import 'package:test/test.dart';
@@ -134,5 +135,43 @@ void main() {
 
       verify(() => mockDio.post(any(), data: any(named: 'data'))).called(1);
     });
+
+
+  test('imageGeneration should return ImageGeneration on success', () async {
+      final prompt = 'Steampunk cat';
+      final model = ImageModel.stableDiffusionXL1_0;
+
+      when(() => mockDio.post(any(), data: any(named: 'data')))
+          .thenAnswer((_) async => Response(
+                requestOptions: RequestOptions(path: ''),
+                data: {
+                "id": "8d712979edf8ef73-PDX",
+                "model": "stabilityai/stable-diffusion-xl-base-1.0",
+                "object": "list",
+                "data": [
+                  {
+                    "index": 0,
+                    "url": "someurl",
+                    "timings": {
+                      "inference": 2561
+                    }
+                  }
+                ]
+              },
+              ));
+
+      final result = await sdk.imageGeneration(prompt, imageModel: model);
+
+      expect(result, isA<ImageGenerationResponse>());
+      expect(result?.id, '8d712979edf8ef73-PDX');
+      expect(result?.object, 'list');
+      expect(result?.model, 'stabilityai/stable-diffusion-xl-base-1.0');
+
+      expect(result?.data.first.index, 0);
+      expect(result?.data.first.url, "someurl");
+
+      verify(() => mockDio.post(any(), data: any(named: 'data'))).called(1);
+    });
   });
+
 }


### PR DESCRIPTION
Hello,

I was working with this package for a study project and noticed that the image generation API always returns `null` but prints out the response to the console.

It seems that the image generation API output format has changed. The docs still state that a field `b64_json` is present, but when running the examples here: [together AI image generation](https://docs.together.ai/reference/post_images-generations), the output has changed and apparently the field is now `url` containing a URL to the image on the together AI server.

I changed that in the model definition and wrote a test for the image generation. Also, I added a method for generating a b64 image data URL out of the URL from the API response.